### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/test/test-generic-post.js
+++ b/test/test-generic-post.js
@@ -127,9 +127,14 @@ describe("check build output for a generic post", () => {
     });
 
     it("should link to twitter with noopener", () => {
-      const twitterLinks = Array.from(doc.querySelectorAll("a")).filter((a) =>
-        a.href.startsWith("https://twitter.com")
-      );
+      const twitterLinks = Array.from(doc.querySelectorAll("a")).filter((a) => {
+        try {
+          const u = new URL(a.href, URL);
+          return u.hostname === "twitter.com" || u.hostname === "www.twitter.com";
+        } catch (e) {
+          return false;
+        }
+      });
       for (let a of twitterLinks) {
         expect(a.rel).to.contain("noopener");
         expect(a.target).to.equal("_blank");


### PR DESCRIPTION
Potential fix for [https://github.com/rynizx/Fortind/security/code-scanning/1](https://github.com/rynizx/Fortind/security/code-scanning/1)

To correctly identify `a` elements that link to Twitter, instead of checking that the `href` starts with `"https://twitter.com"`, parse the URL and verify the exact host using the standard Node.js `URL` class or the built-in `url` module. This prevents misidentifying links such as `https://twitter.com.attacker.com`. The best way to do this without changing any existing logic is to, for each anchor `a`, parse its `href`, and check whether the hostname is exactly `"twitter.com"` or an allowed subdomain like `"www.twitter.com"`. The fix is made in the test/test-generic-post.js file, specifically within the test on line 129-137, changing the filter on line 131. You may need to add an import for the `URL` constructor if not present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
